### PR TITLE
Improve item icon export: unified sizes, 3D block dynamic icons, and lossless PNG compression

### DIFF
--- a/src/main/java/com/iouter/gtnhdumper/common/dumper/ItemIconDumper.java
+++ b/src/main/java/com/iouter/gtnhdumper/common/dumper/ItemIconDumper.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemBlock;
@@ -242,7 +243,8 @@ public class ItemIconDumper extends WikiDumper {
 
     public static void renderDynamicItem(ItemStack itemStack, RenderItem itemRenderer, DynamicTexture dynamicTexture) {
         int frameCount = dynamicTexture.lcm;
-        FBOHelper dynamicFbo = getFbo(getDynamicTextureSize(dynamicTexture));
+        boolean is3dBlockItem = is3dBlockItem(itemStack);
+        FBOHelper dynamicFbo = getFbo(is3dBlockItem ? SINGLE_FRAME_SIZE : getDynamicTextureSize(dynamicTexture));
         BufferedImage[] images = new BufferedImage[frameCount];
         for (int i = 0; i < frameCount; i++) {
             images[dynamicTexture.getIndex()] = renderItem(itemStack, dynamicFbo, itemRenderer, 1f, dynamicTexture);
@@ -263,6 +265,11 @@ public class ItemIconDumper extends WikiDumper {
             resizeImage(images[0], SINGLE_FRAME_SIZE));
         FBOHelper.saveToFile(new File("dumps/icons/" + getIconFileName(itemStack, true)), image);
         dynamicFbo.restoreTexture();
+    }
+
+    private static boolean is3dBlockItem(ItemStack itemStack) {
+        return itemStack.getItem() instanceof ItemBlock
+            && RenderBlocks.renderItemIn3d(((ItemBlock) itemStack.getItem()).field_150939_a.getRenderType());
     }
 
     private static int getDynamicTextureSize(DynamicTexture dynamicTexture) {

--- a/src/main/java/com/iouter/gtnhdumper/common/dumper/ItemIconDumper.java
+++ b/src/main/java/com/iouter/gtnhdumper/common/dumper/ItemIconDumper.java
@@ -20,14 +20,12 @@ import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.IIcon;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
@@ -53,7 +51,9 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 public class ItemIconDumper extends WikiDumper {
 
+    private static final int SINGLE_FRAME_SIZE = 256;
     private static final Object2IntOpenHashMap<ItemStack> frameCountMap = new Object2IntOpenHashMap<>();
+    private static final Object2IntOpenHashMap<ItemStack> dynamicSizeMap = new Object2IntOpenHashMap<>();
     private static final Map<Integer, FBOHelper> fbos = new HashMap<>();
 
     public ItemIconDumper() {
@@ -73,6 +73,8 @@ public class ItemIconDumper extends WikiDumper {
     @Override
     public Iterable<Object[]> dumpObject(int mode) {
         LinkedList<Object[]> list = new LinkedList<>();
+        frameCountMap.clear();
+        dynamicSizeMap.clear();
 
         List<ItemStack> itemStacks = AllItemStacks.getAllItemStacks();
 
@@ -81,7 +83,7 @@ public class ItemIconDumper extends WikiDumper {
 
         for (ItemStack stack : itemStacks) {
             if (Utils.isStackInvalid(stack)) continue;
-            final int size = prepareRenderItem(stack, RenderItem.getInstance());
+            prepareRenderItem(stack, RenderItem.getInstance());
             final String translatedName = EnumChatFormatting
                 .getTextWithoutFormattingCodes(GuiContainerManager.itemDisplayNameShort(stack));
             final String imageName = getIconFileName(stack);
@@ -95,7 +97,9 @@ public class ItemIconDumper extends WikiDumper {
                 }
                 redirectMap.put("File:" + vaildFileName + " " + i + ".png", "File:" + imageName);
             }
-            list.add(new Object[] { Utils.getItemStackShortKey(stack), imageName, size, getItemFrameCount(stack) });
+            list.add(
+                new Object[] { Utils.getItemStackShortKey(stack), imageName, getItemDynamicSize(stack),
+                    getItemFrameCount(stack) });
         }
 
         try (CSVPrinter printer = new CSVPrinter(
@@ -166,32 +170,17 @@ public class ItemIconDumper extends WikiDumper {
         return false;
     }
 
-    public static int prepareRenderItem(ItemStack itemStack, RenderItem itemRenderer) {
-        IIcon iIcon = itemStack.getIconIndex();
-        if (iIcon == null) {
-            iIcon = Objects.requireNonNull(itemStack.getItem())
-                .getIconFromDamageForRenderPass(itemStack.getItemDamage(), 0);
-        }
-        int size;
-        if (itemStack.getItem() instanceof ItemBlock
-            && RenderBlocks.renderItemIn3d(((ItemBlock) itemStack.getItem()).field_150939_a.getRenderType())) {
-            size = 256;
-        } else if (iIcon == null) {
-            GTNHDumper.LOG.error("Can't find {}'s icon, set render size to 128", itemStack.getDisplayName());
-            size = 128;
-        } else {
-            int width = iIcon.getIconWidth();
-            int height = iIcon.getIconHeight();
-            size = Math.max(width, height);
-        }
+    public static void prepareRenderItem(ItemStack itemStack, RenderItem itemRenderer) {
+        renderGeneralItem(itemStack, getFbo(SINGLE_FRAME_SIZE), itemRenderer);
+    }
 
+    private static FBOHelper getFbo(int size) {
         FBOHelper fbo = fbos.get(size);
         if (fbo == null) {
             fbo = new FBOHelper(size);
             fbos.put(size, fbo);
         }
-        renderGeneralItem(itemStack, fbo, itemRenderer);
-        return size;
+        return fbo;
     }
 
     /**
@@ -243,21 +232,20 @@ public class ItemIconDumper extends WikiDumper {
         }
         DynamicTexture dynamicTexture = new DynamicTexture(itemStack);
         if (!getIconFileName(itemStack).contains("Botania:prismarine") && dynamicTexture.isDynamic()) {
-            renderDynamicItem(itemStack, fbo, itemRenderer, dynamicTexture);
+            renderDynamicItem(itemStack, itemRenderer, dynamicTexture);
             return;
         }
-        frameCountMap.put(itemStack, 1);
         BufferedImage image = renderItem(itemStack, fbo, itemRenderer, 1f, null);
         FBOHelper.saveToFile(new File("dumps/icons/" + getIconFileName(itemStack)), image);
         fbo.restoreTexture();
     }
 
-    public static void renderDynamicItem(ItemStack itemStack, FBOHelper fbo, RenderItem itemRenderer,
-        DynamicTexture dynamicTexture) {
+    public static void renderDynamicItem(ItemStack itemStack, RenderItem itemRenderer, DynamicTexture dynamicTexture) {
         int frameCount = dynamicTexture.lcm;
+        FBOHelper dynamicFbo = getFbo(getDynamicTextureSize(dynamicTexture));
         BufferedImage[] images = new BufferedImage[frameCount];
         for (int i = 0; i < frameCount; i++) {
-            images[dynamicTexture.getIndex()] = renderItem(itemStack, fbo, itemRenderer, 1f, dynamicTexture);
+            images[dynamicTexture.getIndex()] = renderItem(itemStack, dynamicFbo, itemRenderer, 1f, dynamicTexture);
         }
         BufferedImage image;
         if (Arrays.stream(images)
@@ -269,9 +257,32 @@ public class ItemIconDumper extends WikiDumper {
         }
         image = concatenateImages(images);
         frameCountMap.put(itemStack, image.getWidth() / image.getHeight());
-        FBOHelper.saveToFile(new File("dumps/icons/" + getIconFileName(itemStack)), images[0]);
+        dynamicSizeMap.put(itemStack, image.getHeight());
+        FBOHelper.saveToFile(
+            new File("dumps/icons/" + getIconFileName(itemStack)),
+            resizeImage(images[0], SINGLE_FRAME_SIZE));
         FBOHelper.saveToFile(new File("dumps/icons/" + getIconFileName(itemStack, true)), image);
-        fbo.restoreTexture();
+        dynamicFbo.restoreTexture();
+    }
+
+    private static int getDynamicTextureSize(DynamicTexture dynamicTexture) {
+        return dynamicTexture.textures.stream()
+            .mapToInt(texture -> Math.max(texture.getIconWidth(), texture.getIconHeight()))
+            .max()
+            .orElse(SINGLE_FRAME_SIZE);
+    }
+
+    private static BufferedImage resizeImage(BufferedImage image, int size) {
+        if (image.getWidth() == size && image.getHeight() == size) {
+            return image;
+        }
+        BufferedImage resized = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = resized.createGraphics();
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+        g2d.setComposite(AlphaComposite.Src);
+        g2d.drawImage(image, 0, 0, size, size, null);
+        g2d.dispose();
+        return resized;
     }
 
     /**
@@ -376,7 +387,11 @@ public class ItemIconDumper extends WikiDumper {
         return true;
     }
 
-    public static int getItemFrameCount(ItemStack stack) {
-        return frameCountMap.getInt(stack);
+    public static Integer getItemDynamicSize(ItemStack stack) {
+        return dynamicSizeMap.containsKey(stack) ? dynamicSizeMap.getInt(stack) : null;
+    }
+
+    public static Integer getItemFrameCount(ItemStack stack) {
+        return frameCountMap.containsKey(stack) ? frameCountMap.getInt(stack) : null;
     }
 }

--- a/src/main/java/com/iouter/gtnhdumper/common/utils/FBOHelper.java
+++ b/src/main/java/com/iouter/gtnhdumper/common/utils/FBOHelper.java
@@ -5,8 +5,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.IntBuffer;
+import java.util.Iterator;
 
+import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
 
 import net.minecraft.client.renderer.GLAllocation;
 
@@ -152,12 +157,40 @@ public final class FBOHelper {
     }
 
     public static void saveToFile(File file, BufferedImage image) {
-        file.mkdirs();
+        File parent = file.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
 
         try {
-            ImageIO.write(image, "png", file);
+            writeMaxCompressedPng(file, image);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static void writeMaxCompressedPng(File file, BufferedImage image) throws IOException {
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("png");
+        if (!writers.hasNext()) {
+            ImageIO.write(image, "png", file);
+            return;
+        }
+        ImageWriter writer = writers.next();
+        ImageWriteParam param = writer.getDefaultWriteParam();
+        if (param.canWriteCompressed()) {
+            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            String[] types = param.getCompressionTypes();
+            if (types != null && types.length > 0) {
+                param.setCompressionType(types[0]);
+            }
+            // PNG 无损：0 = 最大压缩（最慢），导出为离线操作可接受
+            param.setCompressionQuality(0f);
+        }
+        try (ImageOutputStream ios = ImageIO.createImageOutputStream(file)) {
+            writer.setOutput(ios);
+            writer.write(null, new IIOImage(image, null, null), param);
+        } finally {
+            writer.dispose();
         }
     }
 


### PR DESCRIPTION
## Summary

- 单帧图标统一导出为 256px；动图按实际分辨率导出，`size` / `frameCount` 字段只记录动图。
- 3D 方块动图改用 256px 渲染，避免低分辨率 FBO 把模型压小、产生异常留白。
- 所有导出的 PNG 启用最高压缩等级（无损），大幅减小文件体积。

## Details

**图标尺寸**
- 新增 `SINGLE_FRAME_SIZE = 256`，普通单帧固定 256px 渲染。
- 动图长图 `icon_*_dynamic.png` 按动态纹理实际尺寸；3D 方块动图用 256px。
- `size`（动图单帧高度）和 `frameCount` 仅对动图记录，静态图为 `null`。

**无损压缩**
- `FBOHelper.saveToFile` 从默认 `ImageIO.write`（零压缩）改为 `ImageWriteParam` 最高压缩等级写 PNG。
- 对所有图标生效（静态图、动图首帧、动图长图），分辨率/帧数/像素均不变。
- 实测大文件降幅 8%~55%，例如 `icon_Avaritia_Dire_Crafting_dynamic.png` 从 4.9MB 降到 2.2MB。